### PR TITLE
fix: no "Start Task" when config specs dir

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -106,12 +106,19 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Register CodeLens provider for spec tasks
     const specTaskCodeLensProvider = new SpecTaskCodeLensProvider();
+
+    let specDir = '.claude/specs';
+    try {
+        const configManager = ConfigManager.getInstance();
+        await configManager.loadSettings()
+        specDir = configManager.getPath('specs');
+    } catch (error) {}
     
     // 使用更明确的文档选择器
     const selector: vscode.DocumentSelector = [
         { 
             language: 'markdown', 
-            pattern: '**/.claude/specs/*/tasks.md',
+            pattern: `**/${specDir}/*/tasks.md`,
             scheme: 'file'
         }
     ];

--- a/src/providers/specTaskCodeLensProvider.ts
+++ b/src/providers/specTaskCodeLensProvider.ts
@@ -1,18 +1,23 @@
 import * as vscode from 'vscode';
+import { ConfigManager } from '../utils/configManager';
 
 export class SpecTaskCodeLensProvider implements vscode.CodeLensProvider {
     private _onDidChangeCodeLenses: vscode.EventEmitter<void> = new vscode.EventEmitter<void>();
     public readonly onDidChangeCodeLenses: vscode.Event<void> = this._onDidChangeCodeLenses.event;
+    private configManager: ConfigManager;
 
     constructor() {
+        this.configManager = ConfigManager.getInstance();
+        this.configManager.loadSettings();
         vscode.workspace.onDidChangeConfiguration((_) => {
             this._onDidChangeCodeLenses.fire();
         });
     }
 
     public provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
-        // Pattern is already filtered by registration, but double-check for tasks.md
-        if (!document.fileName.includes('.claude/specs/') || !document.fileName.endsWith('tasks.md')) {
+        // Pattern is already filtered by registration, but double-check for tasks.md  
+        const specDir = this.configManager.getPath('specs');
+        if (!document.fileName.includes(specDir) || !document.fileName.endsWith('tasks.md')) {
             return [];
         }
 


### PR DESCRIPTION
fix when change paths settings, the `tasks.md` no show the "Start Task"